### PR TITLE
Cargo: Only include files necessary to the build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ name = "analiticcl"
 readme = "README.md"
 repository = "https://github.com/proycon/analiticcl"
 version = "0.3.0"
+include = ["src/**/*", "LICENSE", "README.md"]
+
 [[bench]]
 harness = false
 name = "benchmarks"


### PR DESCRIPTION
This removed 94% of the crate's contents by size, mostly data files under `examples/`.

Found via [`cargo-diet`] and the [`crates.io` waste report].
Many thanks to the Lean Crate Initiative, and @Byron in particular.

[`cargo-diet`]: https://github.com/the-lean-crate/cargo-diet
[`crates.io` waste report]: https://the-lean-crate.github.io/waste/
